### PR TITLE
New version allowing parallel testing.

### DIFF
--- a/cucumber-reports.iml
+++ b/cucumber-reports.iml
@@ -32,7 +32,6 @@
     <orderEntry type="library" name="Maven: org.apache.maven:maven-artifact:2.0.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-provider-api:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven:maven-plugin-registry:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: com.googlecode.totallylazy:totallylazy:1077" level="project" />
     <orderEntry type="library" name="Maven: org.jsoup:jsoup:1.7.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main:jenkins-war:war:1.511" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci.main:jenkins-core:1.511" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,12 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>http://repo.jenkins-ci.org/public/</url>            
         </repository>
+        <repository>
+            <id>repo.bodar.com</id>
+            <url>http://repo.bodar.com</url>
+          </repository>
     </repositories>
 
     <pluginRepositories>
@@ -82,5 +86,10 @@
             <artifactId>cucumber-reporting</artifactId>
             <version>0.0.23</version>
         </dependency>
+        <dependency>
+          <groupId>com.googlecode.totallylazy</groupId>
+          <artifactId>totallylazy</artifactId>
+          <version>1077</version>
+       </dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -31,15 +31,17 @@ public class CucumberReportPublisher extends Recorder {
     public final boolean undefinedFails;
     public final boolean noFlashCharts;
 	public final boolean ignoreFailedTests;
+    public final boolean parallelTesting;
 
     @DataBoundConstructor
-    public CucumberReportPublisher(String jsonReportDirectory, String pluginUrlPath, boolean skippedFails, boolean undefinedFails, boolean noFlashCharts, boolean ignoreFailedTests) {
+    public CucumberReportPublisher(String jsonReportDirectory, String pluginUrlPath, boolean skippedFails, boolean undefinedFails, boolean noFlashCharts, boolean ignoreFailedTests, boolean parallelTesting) {
         this.jsonReportDirectory = jsonReportDirectory;
         this.pluginUrlPath = pluginUrlPath;
         this.skippedFails = skippedFails;
         this.undefinedFails = undefinedFails;
         this.noFlashCharts = noFlashCharts;
 		this.ignoreFailedTests = ignoreFailedTests;
+        this.parallelTesting = parallelTesting;
     }
 
     private String[] findJsonFiles(File targetDirectory) {
@@ -93,7 +95,7 @@ public class CucumberReportPublisher extends Recorder {
             }
             listener.getLogger().println("[CucumberReportPublisher] Generating HTML reports");
 
-            try {
+            try {                
                 ReportBuilder reportBuilder = new ReportBuilder(
                         fullPathToJsonFiles(jsonReportFiles, targetBuildDirectory),
                         targetBuildDirectory,
@@ -106,7 +108,7 @@ public class CucumberReportPublisher extends Recorder {
                         true,
                         false,
                         "",
-                        false);
+                        false,parallelTesting);
                 reportBuilder.generateReports();
 
 				boolean buildSuccess = reportBuilder.getBuildStatus();

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
@@ -28,6 +28,9 @@
                 </f:entry>	
 			<f:entry title="Ignore failed tests" field="ignoreFailedTests" description="Tick this if you don't want the entire build to fail when these tests fail. If so, build becomes unstable">
 				<f:checkbox />
+        </f:entry>
+        <f:entry title="Parallel testing" field="parallelTesting" description="Tick this if you are going to run same test in parallel for multiple devices.">
+        <f:checkbox />
 			</f:entry>
         </f:advanced>
 </j:jelly>


### PR DESCRIPTION
Solving issue: https://github.com/masterthought/jenkins-cucumber-jvm-reports-plugin-java/issues/99

Once the plugin is installed, you have a new option in Advanced options to select parallel testing. This will change Parallel property in Cucumber-reporting, creating one report per device, when tests are being launched in parallel.
